### PR TITLE
Add support for Adj-RIB-Out, O-flag

### DIFF
--- a/Server/src/MsgBusInterface.hpp
+++ b/Server/src/MsgBusInterface.hpp
@@ -107,6 +107,7 @@ public:
         uint32_t    peer_as;                ///< Peer ASN
         bool        isL3VPN;                ///< true if peer is L3VPN, otherwise it is Global
         bool        isPrePolicy;            ///< True if the routes are pre-policy, false if not
+        bool        isAdjIn;                ///< True if the routes are Adj-Rib-In, false if not
         bool        isIPv4;                 ///< true if peer is IPv4 or false if IPv6
         uint32_t    timestamp_secs;         ///< Timestamp in seconds since EPOC
         uint32_t    timestamp_us;           ///< Timestamp microseconds

--- a/Server/src/bmp/parseBMP.cpp
+++ b/Server/src/bmp/parseBMP.cpp
@@ -385,13 +385,18 @@ void parseBMP::parsePeerHdr(int sock) {
                    peer_addr);
     }
 
-    if (p_hdr.peer_flags & 0x40) { // L flag of 1 means this is post-policy of Adj-RIB-In
+    if (p_hdr.peer_flags & 0x10) { // O flag of 1 means this is Adj-Rib-Out
+        SELF_DEBUG("sock=%d : Msg is for Adj-RIB-Out", sock);
+        p_entry->isPrePolicy = false;
+        p_entry->isAdjIn = false;
+    } else if (p_hdr.peer_flags & 0x40) { // L flag of 1 means this is post-policy of Adj-RIB-In
         SELF_DEBUG("sock=%d : Msg is for POST-POLICY Adj-RIB-In", sock);
         p_entry->isPrePolicy = false;
-
+        p_entry->isAdjIn = true;
     } else {
         SELF_DEBUG("sock=%d : Msg is for PRE-POLICY Adj-RIB-In", sock);
         p_entry->isPrePolicy = true;
+        p_entry->isAdjIn = true;
     }
 
     // convert the BMP byte messages to human readable strings

--- a/Server/src/kafka/MsgBusImpl_kafka.cpp
+++ b/Server/src/kafka/MsgBusImpl_kafka.cpp
@@ -812,7 +812,8 @@ void msgBus_kafka::update_unicastPrefix(obj_bgp_peer &peer, std::vector<obj_rib>
 
                 buf_len += snprintf(buf2, sizeof(buf2),
                                     "%s\t%" PRIu64 "\t%s\t%s\t%s\t%s\t%s\t%s\t%" PRIu32 "\t%s\t%s\t%d\t%d\t%s\t%s\t%" PRIu16
-                                            "\t%" PRIu32 "\t%s\t%" PRIu32 "\t%" PRIu32 "\t%s\t%s\t%s\t%s\t%d\t%d\t%s\t%" PRIu32 "\t%s\n",
+                                            "\t%" PRIu32 "\t%s\t%" PRIu32 "\t%" PRIu32 "\t%s\t%s\t%s\t%s\t%d\t%d\t%s\t%" PRIu32
+                                            "\t%s\t%d\t%d\n",
                                     action.c_str(), unicast_prefix_seq, rib_hash_str.c_str(), r_hash_str.c_str(),
                                     router_ip.c_str(),path_hash_str.c_str(), p_hash_str.c_str(),
                                     peer.peer_addr, peer.peer_as, ts.c_str(), rib[i].prefix, rib[i].prefix_len,
@@ -821,16 +822,17 @@ void msgBus_kafka::update_unicastPrefix(obj_bgp_peer &peer, std::vector<obj_rib>
                                     attr->aggregator,
                                     attr->community_list.c_str(), attr->ext_community_list.c_str(), attr->cluster_list.c_str(),
                                     attr->atomic_agg, attr->nexthop_isIPv4,
-                                    attr->originator_id, rib[i].path_id, rib[i].labels);
+                                    attr->originator_id, rib[i].path_id, rib[i].labels, peer.isPrePolicy, peer.isAdjIn);
                 break;
 
             case UNICAST_PREFIX_ACTION_DEL:
                 buf_len += snprintf(buf2, sizeof(buf2),
-                                    "%s\t%" PRIu64 "\t%s\t%s\t%s\t\t%s\t%s\t%" PRIu32 "\t%s\t%s\t%d\t%d\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t%" PRIu32 "\t%s\n",
+                                    "%s\t%" PRIu64 "\t%s\t%s\t%s\t\t%s\t%s\t%" PRIu32 "\t%s\t%s\t%d\t%d\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t%" PRIu32
+                                            "\t%s\t%d\t%d\n",
                                     action.c_str(), unicast_prefix_seq, rib_hash_str.c_str(), r_hash_str.c_str(),
                                     router_ip.c_str(), p_hash_str.c_str(),
                                     peer.peer_addr, peer.peer_as, ts.c_str(), rib[i].prefix, rib[i].prefix_len,
-                                    rib[i].isIPv4, rib[i].path_id, rib[i].labels);
+                                    rib[i].isIPv4, rib[i].path_id, rib[i].labels, peer.isPrePolicy, peer.isAdjIn);
                 break;
         }
 
@@ -969,11 +971,12 @@ void msgBus_kafka::update_LsNode(obj_bgp_peer &peer, obj_path_attr &attr, std::l
 
         buf_len += snprintf(buf2, sizeof(buf2),
                         "%s\t%" PRIu64 "\t%s\t%s\t%s\t%s\t%s\t%s\t%" PRIu32 "\t%s\t%s\t%s\t%" PRIx64 "\t%" PRIx32 "\t%s"
-                                "\t%s\t%s\t%s\t%s\t%s\t%" PRIu32 "\t%" PRIu32 "\t%s\t%s\n",
+                                "\t%s\t%s\t%s\t%s\t%s\t%" PRIu32 "\t%" PRIu32 "\t%s\t%s\t%d\t%d\n",
                         action.c_str(),ls_node_seq, hash_str.c_str(),path_hash_str.c_str(), r_hash_str.c_str(),
                         router_ip.c_str(), peer_hash_str.c_str(), peer.peer_addr, peer.peer_as, ts.c_str(),
                         igp_router_id, router_id, node.id, node.bgp_ls_id,node.mt_id, ospf_area_id, isis_area_id,
-                        node.protocol, node.flags, attr.as_path.c_str(), attr.local_pref, attr.med, attr.next_hop, node.name);
+                        node.protocol, node.flags, attr.as_path.c_str(), attr.local_pref, attr.med, attr.next_hop, node.name,
+                        peer.isPrePolicy, peer.isAdjIn);
 
         // Cat the entry to the query buff
         if (buf_len < MSGBUS_WORKING_BUF_SIZE /* size of buf */)
@@ -1122,7 +1125,7 @@ void msgBus_kafka::update_LsLink(obj_bgp_peer &peer, obj_path_attr &attr, std::l
                 "%s\t%" PRIu64 "\t%s\t%s\t%s\t%s\t%s\t%s\t%" PRIu32 "\t%s\t%s\t%s\t%" PRIx64 "\t%" PRIx32 "\t%s\t%s\t%s\t%s\t%"
                         PRIu32 "\t%" PRIu32 "\t%s\t%" PRIx32 "\t%" PRIu32 "\t%" PRIu32 "\t%s\t%s\t%" PRIu32 "\t%" PRIu32
                         "\t%" PRIu32 "\t%" PRIu32 "\t%s\t%" PRIu32 "\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%" PRIu32 ""
-                        "\t%" PRIu32 "\t%s\n",
+                        "\t%" PRIu32 "\t%s\t%d\t%d\n",
                             action.c_str(), ls_link_seq, hash_str.c_str(), path_hash_str.c_str(),r_hash_str.c_str(),
                             router_ip.c_str(), peer_hash_str.c_str(), peer.peer_addr, peer.peer_as, ts.c_str(),
                             igp_router_id, router_id, link.id, link.bgp_ls_id, ospf_area_id,
@@ -1131,7 +1134,7 @@ void msgBus_kafka::update_LsLink(obj_bgp_peer &peer, obj_path_attr &attr, std::l
                             link.admin_group, link.max_link_bw, link.max_resv_bw, link.unreserved_bw, link.te_def_metric,
                             link.protection_type, link.mpls_proto_mask, link.srlg, link.name, remote_node_hash_id.c_str(),
                             local_node_hash_id.c_str(),remote_igp_router_id, remote_router_id,
-                            link.local_node_asn,link.remote_node_asn, link.peer_node_sid);
+                            link.local_node_asn,link.remote_node_asn, link.peer_node_sid, peer.isPrePolicy, peer.isAdjIn);
 
         // Cat the entry to the query buff
         if (buf_len < MSGBUS_WORKING_BUF_SIZE /* size of buf */)
@@ -1266,13 +1269,13 @@ void msgBus_kafka::update_LsPrefix(obj_bgp_peer &peer, obj_path_attr &attr, std:
         buf_len += snprintf(buf2, sizeof(buf2),
                 "%s\t%" PRIu64 "\t%s\t%s\t%s\t%s\t%s\t%s\t%" PRIu32 "\t%s\t%s\t%s\t%" PRIx64 "\t%" PRIx32
                         "\t%s\t%s\t%s\t%s\t%" PRIu32 "\t%" PRIu32 "\t%s\t%s\t%" PRIx32 "\t%s\t%s\t%" PRIu32 "\t%" PRIx64
-                            "\t%s\t%" PRIu32 "\t%s\t%d\n",
+                            "\t%s\t%" PRIu32 "\t%s\t%d\t%d\t%d\n",
                             action.c_str(), ls_prefix_seq, hash_str.c_str(), path_hash_str.c_str(), r_hash_str.c_str(),
                             router_ip.c_str(), peer_hash_str.c_str(), peer.peer_addr, peer.peer_as, ts.c_str(),
                             igp_router_id, router_id, prefix.id, prefix.bgp_ls_id, ospf_area_id, isis_area_id,
                             prefix.protocol, attr.as_path.c_str(), attr.local_pref, attr.med, attr.next_hop, local_node_hash_id.c_str(),
                             prefix.mt_id, prefix.ospf_route_type, prefix.igp_flags, prefix.route_tag, prefix.ext_route_tag,
-                            ospf_fwd_addr, prefix.metric, prefix_ip, prefix.prefix_len);
+                            ospf_fwd_addr, prefix.metric, prefix_ip, prefix.prefix_len, peer.isPrePolicy, peer.isAdjIn);
 
         // Cat the entry to the query buff
         if (buf_len < MSGBUS_WORKING_BUF_SIZE /* size of buf */)

--- a/Server/src/kafka/MsgBusImpl_kafka.h
+++ b/Server/src/kafka/MsgBusImpl_kafka.h
@@ -38,7 +38,7 @@
 class msgBus_kafka: public MsgBusInterface {
 public:
     #define MSGBUS_WORKING_BUF_SIZE         1800000
-    #define MSGBUS_API_VERSION              "1.2"
+    #define MSGBUS_API_VERSION              "1.3"
 
     /******************************************************************//**
      * \brief This function will initialize and connect to MySQL.  

--- a/docs/MESSAGE_BUS_API.md
+++ b/docs/MESSAGE_BUS_API.md
@@ -1,6 +1,6 @@
 # Message Bus API Specficiation
 
-> #### Current Version 1.2
+> #### Current Version 1.3
 
 
 ## Version Diff

--- a/docs/MESSAGE_BUS_API.md
+++ b/docs/MESSAGE_BUS_API.md
@@ -5,6 +5,25 @@
 
 ## Version Diff
 
+### Diff from 1.3 to 1.2
+
+* **unicast_prefix**
+    * Added **field 30** - Flag indicating if unicast BGP prefix is Pre-Policy Adj-RIB-In or Post-Policy Adj-RIB-In
+    * Added **field 31** - Flag indicating if unicast BGP prefix is Adj-RIB-In or Adj-RIB-Out
+
+* **ls_node**
+    * Added **field 25** - Flag indicating if LS node BGP prefix is Pre-Policy Adj-RIB-In or Post-Policy Adj-RIB-In
+    * Added **field 26** - Flag indicating if LS node BGP prefix is Adj-RIB-In or Adj-RIB-Out
+
+* **ls_link**
+    * Added **field 44** - Flag indicating if LS link BGP prefix is Pre-Policy Adj-RIB-In or Post-Policy Adj-RIB-In
+    * Added **field 45** - Flag indicating if LS link BGP prefix is Adj-RIB-In or Adj-RIB-Out
+
+* **ls_prefix**
+    * Added **field 32** - Flag indicating if LS prefix BGP prefix is Pre-Policy Adj-RIB-In or Post-Policy Adj-RIB-In
+    * Added **field 33** - Flag indicating if LS prefix BGP prefix is Adj-RIB-In or Adj-RIB-Out
+
+
 ### Diff from 1.2 to 1.1
 
 * **ls_link**
@@ -252,7 +271,11 @@ One or more IPv4/IPv6 unicast prefixes.
 26 | isNextHopIPv4 | Bool | 1 | Indicates if the next hop address is IPv4 or not
 27 | Originator Id | String | 46 | Originator ID in printed form (IP)
 28 | Path ID | Int | 4 | Unsigned 32 bit value for the path ID (draft-ietf-idr-add-paths-15).  Zero means add paths is not enabled/used.
-29 | Labels | String | 255 | Comma delimited list of 32bit unsigned values that represent the received labels. 
+29 | Labels | String | 255 | Comma delimited list of 32bit unsigned values that represent the received labels.
+30 | isPrePolicy | Bool | 1 | Indicates if unicast BGP prefix is Pre-Policy Adj-RIB-In or Post-Policy Adj-RIB-In
+31 | isAdjIn | Bool | 1 | Indicates if unicast BGP prefix is Adj-RIB-In or Adj-RIB-Out
+
+
 
 ### Object: <font color="blue">ls\_node</font> (openbmp.parsed.ls\_node)
 One or more link-state nodes.
@@ -283,6 +306,8 @@ One or more link-state nodes.
 22 | MED | Int | 4 | BGP MED value
 23 | Next Hop | String | 46 | BGP next hop IP address in printed form
 24 | Node Name | String | 255 | ISIS hostname
+25 | isPrePolicy | Bool | 1 | Indicates if LS node BGP prefix is Pre-Policy Adj-RIB-In or Post-Policy Adj-RIB-In
+26 | isAdjIn | Bool | 1 | Indicates if LS node BGP prefix is Adj-RIB-In or Adj-RIB-Out
 
 
 ### Object: <font color="blue">ls\_link</font> (openbmp.parsed.ls\_link)
@@ -333,7 +358,8 @@ One or more link-state links.
 41 | Local Node ASN | Int | 4 | Local Node descriptor ASN
 42 | Remote Node ASN | Int | 4 | Remote Node descriptor ASN
 43 | EPE Peer Node SID | String | 128 | Peer node SID in the format of [L] <weight> <label/idx/ipv4>. L is only set when L flag is set.
-
+44 | isPrePolicy | Bool | 1 | Indicates if LS link BGP prefix is Pre-Policy Adj-RIB-In or Post-Policy Adj-RIB-In
+45 | isAdjIn | Bool | 1 | Indicates if LS link BGP prefix is Adj-RIB-In or Adj-RIB-Out
 
 ### Object: <font color="blue">ls\_prefix</font> (openbmp.parsed.ls\_prefix)
 One or more link-state prefixes.
@@ -371,6 +397,8 @@ One or more link-state prefixes.
 29 | IGP Metric | Int | 4 | Unsigned 32bit igp metric value
 30 | Prefix | String | 46 | Printed form of the IP address/prefix
 31 | Prefix Length | Int | 1 | Prefix length in bits
+32 | isPrePolicy | Bool | 1 | Indicates if LS prefix BGP prefix is Pre-Policy Adj-RIB-In or Post-Policy Adj-RIB-In
+33 | isAdjIn | Bool | 1 | Indicates if LS prefix BGP prefix is Adj-RIB-In or Adj-RIB-Out
 
 Message API: BMP RAW Data
 ------------------------------------


### PR DESCRIPTION
1. Version 1.3 adds support for the 0 flag, 0x10 in the peer header indicating if the unicast/LS prefix is ADJ-RIB-Out. 
2. The L flag 0x40 in the peer header is also added to the Kafka raw message for unicast/LS prefixes.
3. Documentation is updated to indicate which fields have been added to the Kafka messages.