### PR TITLE
Add Path Capability parsing in BGP Open Message

### DIFF
--- a/Server/src/bgp/OpenMsg.cpp
+++ b/Server/src/bgp/OpenMsg.cpp
@@ -7,7 +7,6 @@
  *
  */
 #include "OpenMsg.h"
-#include "BMPReader.h"
 
 #include <string>
 #include <list>

--- a/Server/src/bgp/OpenMsg.cpp
+++ b/Server/src/bgp/OpenMsg.cpp
@@ -7,6 +7,7 @@
  *
  */
 #include "OpenMsg.h"
+#include "BMPReader.h"
 
 #include <string>
 #include <list>
@@ -188,11 +189,52 @@ size_t OpenMsg::parseCapabilities(u_char *data, size_t size,  uint32_t &asn, std
                         break;
 
                     case BGP_CAP_ADD_PATH: {
-                        //TODO: Decode ADD PATH AFI/SAFI's that are enabled.  Need to update peer_info_map for each afi/safi
+                        cap_add_path_data data;
 
-                        SELF_DEBUG("%s: supports add-path", peer_addr.c_str());
-                        snprintf(capStr, sizeof(capStr), "ADD Path (%d)", BGP_CAP_ADD_PATH);
-                        capabilities.push_back(capStr);
+                        if(cap->len == sizeof(data)){
+                            memcpy(&data, (cap_ptr + 2), sizeof(data));
+                            bgp::SWAP_BYTES(&data.afi);
+
+                            snprintf(capStr, sizeof(capStr), "ADD Path (%d) : afi=%d safi=%d send/receive=%d",
+                                     BGP_CAP_ADD_PATH, data.afi, data.safi, data.send_recieve);
+
+                            SELF_DEBUG("%s: supports Add Path afi = %d safi = %d send/receive = %d",
+                                       peer_addr.c_str(), data.afi, data.safi, data.send_recieve);
+
+                            std::string decodeStr(capStr);
+                            decodeStr.append(" : ");
+
+                            decodeStr.append(bgp::GET_SAFI_STRING_BY_CODE(data.safi));
+                            decodeStr.append(" ");
+
+                            decodeStr.append(bgp::GET_AFI_STRING_BY_CODE(data.afi));
+                            decodeStr.append(" ");
+
+                            switch (data.send_recieve) {
+                                case BGP_CAP_ADD_PATH_SEND :
+                                    decodeStr.append("Send");
+                                    break;
+
+                                case BGP_CAP_ADD_PATH_RECEIVE :
+                                    decodeStr.append("Receive");
+                                    break;
+
+                                case BGP_CAP_ADD_PATH_SEND_RECEIVE :
+                                    decodeStr.append("Send/Receive");
+                                    break;
+
+                                default:
+                                    decodeStr.append("unknown");
+                                    break;
+                            }
+
+                            capabilities.push_back(decodeStr);
+                        } else {
+                            LOG_NOTICE("%s: ADD PATH capability but length %d is invalid expected %d.",
+                                       peer_addr.c_str(), cap->len, sizeof(data));
+                            return 0;
+                        }
+
                         break;
                     }
 
@@ -227,86 +269,13 @@ size_t OpenMsg::parseCapabilities(u_char *data, size_t size,  uint32_t &asn, std
                             snprintf(capStr, sizeof(capStr), "MPBGP (%d) : afi=%d safi=%d",
                                      BGP_CAP_MPBGP, data.afi, data.safi);
 
-                            /*
-                             * Decode the SAFI - http://www.iana.org/assignments/safi-namespace/safi-namespace.xhtml
-                             */
-                            std::string decode_str = "unknown";
-                            switch (data.safi) {
-                                case bgp::BGP_SAFI_UNICAST : // Unicast IP forwarding
-                                    decode_str = "Unicast";
-                                    break;
+                            ///Building capability string
 
-                                case bgp::BGP_SAFI_MULTICAST : // Multicast IP forwarding
-                                    decode_str = "Multicast";
-                                    break;
-
-                                case bgp::BGP_SAFI_NLRI_LABEL : // NLRI with MPLS Labels
-                                    decode_str = "Labeled Unicast";
-                                    break;
-
-                                case bgp::BGP_SAFI_MCAST_VPN : // MCAST VPN
-                                    decode_str = "MCAST VPN";
-                                    break;
-
-                                case bgp::BGP_SAFI_VPLS : // VPLS
-                                    decode_str = "VPLS";
-                                    break;
-
-                                case bgp::BGP_SAFI_MDT : // BGP MDT
-                                    decode_str = "BGP MDT";
-                                    break;
-
-                                case bgp::BGP_SAFI_4over6 : // BGP 4over6
-                                    decode_str = "BGP 4over6";
-                                    break;
-
-                                case bgp::BGP_SAFI_6over4 : // BGP 6over4
-                                    decode_str = "BGP 6over4";
-                                    break;
-
-                                case bgp::BGP_SAFI_EVPN : // BGP EVPNs
-                                    decode_str = "BGP EVPNs";
-                                    break;
-
-                                case bgp::BGP_SAFI_BGPLS : // BGP-LS
-                                    decode_str = "BGP-LS";
-                                    break;
-
-                                case bgp::BGP_SAFI_MPLS : // MPLS-Labeled VPN
-                                    decode_str = "MPLS-Labeled VPN";
-                                    break;
-
-                                case bgp::BGP_SAFI_MCAST_MPLS_VPN : // Multicast BGP/MPLS VPN
-                                    decode_str = "Multicast BGP/MPLS VPN";
-                                    break;
-
-                                case bgp::BGP_SAFI_RT_CONSTRAINS : // Route target constrains
-                                    decode_str = "RT constrains";
-                                    break;
-                            }
-
-                            // Add decoded string with address family type
                             std::string decodedStr(capStr);
                             decodedStr.append(" : ");
-                            decodedStr.append(decode_str);
-
-                            switch (data.afi) {
-                                case bgp::BGP_AFI_IPV4 :
-                                    decodedStr.append(" IPv4");
-                                    break;
-
-                                case bgp::BGP_AFI_IPV6 :
-                                    decodedStr.append(" IPv6");
-                                    break;
-
-                                case bgp::BGP_AFI_BGPLS :
-                                    decodedStr.append(" BGP-LS");
-                                    break;
-
-                                default:
-                                    decodedStr.append(" unknown");
-                                    break;
-                            }
+                            decodedStr.append(bgp::GET_SAFI_STRING_BY_CODE(data.safi));
+                            decodedStr.append(" ");
+                            decodedStr.append(bgp::GET_AFI_STRING_BY_CODE(data.afi));
 
                             capabilities.push_back(decodedStr);
 

--- a/Server/src/bgp/OpenMsg.h
+++ b/Server/src/bgp/OpenMsg.h
@@ -12,6 +12,7 @@
 
 #include "Logger.h"
 #include "bgp_common.h"
+#include "BMPReader.h"
 
 #include <list>
 
@@ -49,6 +50,16 @@ public:
     };
 
     /**
+     * Defines the Add Path BGP capability's send/recieve code
+     *      https://tools.ietf.org/html/rfc7911#section-4
+     */
+    enum BGP_CAP_ADD_PATH_SEND_RECEIVE_CODES {
+            BGP_CAP_ADD_PATH_RECEIVE=1,
+            BGP_CAP_ADD_PATH_SEND=2,
+            BGP_CAP_ADD_PATH_SEND_RECEIVE=3
+    };
+
+    /**
      * defines the Capability BGP header per RFC5492
      *      http://www.iana.org/assignments/capability-codes/capability-codes.xhtml
      */
@@ -65,6 +76,15 @@ public:
           u_char         reserved;               ///< Unused
           u_char         safi;                   ///< Subsequent address family
       } __attribute__ ((__packed__));
+
+    /**
+    * Defines the Add Path capability data
+    */
+    struct cap_add_path_data {
+        uint16_t       afi;
+        uint8_t        safi;
+        uint8_t        send_recieve;
+    } __attribute__ ((__packed__));
 
     /**
      * defines the OPEN BGP header per RFC4271

--- a/Server/src/bgp/OpenMsg.h
+++ b/Server/src/bgp/OpenMsg.h
@@ -12,7 +12,6 @@
 
 #include "Logger.h"
 #include "bgp_common.h"
-#include "BMPReader.h"
 
 #include <list>
 

--- a/Server/src/bgp/bgp_common.h
+++ b/Server/src/bgp/bgp_common.h
@@ -183,9 +183,6 @@ namespace bgp {
         return afi_string;
     }
 
-    /*
-     * Decode the SAFI - http://www.iana.org/assignments/safi-namespace/safi-namespace.xhtml
-     */
     /**
      * Function to get string representation of SAFI code.
      * @param code SAFI http://www.iana.org/assignments/safi-namespace/safi-namespace.xhtml

--- a/Server/src/bgp/bgp_common.h
+++ b/Server/src/bgp/bgp_common.h
@@ -155,6 +155,102 @@ namespace bgp {
 
     }
 
+    /**
+     * Function to get string representation of AFI code.
+     * @param code AFI http://www.iana.org/assignments/address-family-numbers/address-family-numbers.xhtml
+     * @return string like "IPv6" or "IPv4"
+     */
+    inline std::string GET_AFI_STRING_BY_CODE(int code) {
+        std::string afi_string;
+
+        switch (code) {
+            case bgp::BGP_AFI_IPV4 :
+                afi_string = "IPv4";
+                break;
+
+            case bgp::BGP_AFI_IPV6 :
+                afi_string = "IPv6";
+                break;
+
+            case bgp::BGP_AFI_BGPLS :
+                afi_string = "BGP-LS";
+                break;
+
+            default:
+                afi_string = "unknown";
+                break;
+        }
+        return afi_string;
+    }
+
+    /*
+     * Decode the SAFI - http://www.iana.org/assignments/safi-namespace/safi-namespace.xhtml
+     */
+    /**
+     * Function to get string representation of SAFI code.
+     * @param code SAFI http://www.iana.org/assignments/safi-namespace/safi-namespace.xhtml
+     * @return string like "Unicast" or "Multicast"
+     */
+    inline std::string GET_SAFI_STRING_BY_CODE(int code) {
+        std::string safi_string;
+
+        switch (code) {
+            case bgp::BGP_SAFI_UNICAST : // Unicast IP forwarding
+                safi_string = "Unicast";
+                break;
+
+            case bgp::BGP_SAFI_MULTICAST : // Multicast IP forwarding
+                safi_string = "Multicast";
+                break;
+
+            case bgp::BGP_SAFI_NLRI_LABEL : // NLRI with MPLS Labels
+                safi_string = "Labeled Unicast";
+                break;
+
+            case bgp::BGP_SAFI_MCAST_VPN : // MCAST VPN
+                safi_string = "MCAST VPN";
+                break;
+
+            case bgp::BGP_SAFI_VPLS : // VPLS
+                safi_string = "VPLS";
+                break;
+
+            case bgp::BGP_SAFI_MDT : // BGP MDT
+                safi_string = "BGP MDT";
+                break;
+
+            case bgp::BGP_SAFI_4over6 : // BGP 4over6
+                safi_string = "BGP 4over6";
+                break;
+
+            case bgp::BGP_SAFI_6over4 : // BGP 6over4
+                safi_string = "BGP 6over4";
+                break;
+
+            case bgp::BGP_SAFI_EVPN : // BGP EVPNs
+                safi_string = "BGP EVPNs";
+                break;
+
+            case bgp::BGP_SAFI_BGPLS : // BGP-LS
+                safi_string = "BGP-LS";
+                break;
+
+            case bgp::BGP_SAFI_MPLS : // MPLS-Labeled VPN
+                safi_string = "MPLS-Labeled VPN";
+                break;
+
+            case bgp::BGP_SAFI_MCAST_MPLS_VPN : // Multicast BGP/MPLS VPN
+                safi_string = "Multicast BGP/MPLS VPN";
+                break;
+
+            case bgp::BGP_SAFI_RT_CONSTRAINS : // Route target constrains
+                safi_string = "RT constrains";
+                break;
+
+        }
+        return safi_string;
+    }
+
 }
 
 #endif /* BGPCOMMON_H */


### PR DESCRIPTION
Added Add Path Capability parsing in BGP Open Message.

Implemented using RFC:  https://tools.ietf.org/html/rfc7911#section-4