### PR TITLE
Add support for default route adevrtisements in BMP server and fix no…

### DIFF
--- a/Server/src/bgp/MPReachAttr.cpp
+++ b/Server/src/bgp/MPReachAttr.cpp
@@ -228,26 +228,23 @@ void MPReachAttr::parseNlriData_IPv4IPv6(bool isIPv4, u_char *data, uint16_t len
         if (tuple.len % 8)
            ++addr_bytes;
 
-        // if the route isn't a default route
-        if (addr_bytes > 0) {
-            memcpy(ip_raw, data, addr_bytes);
-            data += addr_bytes;
-            read_size += addr_bytes;
+        memcpy(ip_raw, data, addr_bytes);
+        data += addr_bytes;
+        read_size += addr_bytes;
 
-            // Convert the IP to string printed format
-            if (isIPv4)
-                inet_ntop(AF_INET, ip_raw, ip_char, sizeof(ip_char));
-            else
-                inet_ntop(AF_INET6, ip_raw, ip_char, sizeof(ip_char));
+        // Convert the IP to string printed format
+        if (isIPv4)
+            inet_ntop(AF_INET, ip_raw, ip_char, sizeof(ip_char));
+        else
+            inet_ntop(AF_INET6, ip_raw, ip_char, sizeof(ip_char));
 
-            tuple.prefix.assign(ip_char);
+        tuple.prefix.assign(ip_char);
 
-            // set the raw/binary address
-            memcpy(tuple.prefix_bin, ip_raw, sizeof(ip_raw));
-          
-            // Add tuple to prefix list
-            prefixes.push_back(tuple);
-        }
+        // set the raw/binary address
+        memcpy(tuple.prefix_bin, ip_raw, sizeof(ip_raw));
+
+        // Add tuple to prefix list
+        prefixes.push_back(tuple);
     }
 }
 

--- a/Server/src/bgp/UpdateMsg.cpp
+++ b/Server/src/bgp/UpdateMsg.cpp
@@ -203,8 +203,7 @@ void UpdateMsg::parseNlriData_v4(u_char *data, uint16_t len, std::list<bgp::pref
         SELF_DEBUG("%s: rtr=%s: Reading NLRI data prefix bits=%d bytes=%d", peer_addr.c_str(),
                     router_addr.c_str(), tuple.len, addr_bytes);
 
-        // if the route isn't a default route
-        if (addr_bytes > 0 and addr_bytes <= 4) {
+        if (addr_bytes <= 4) {
             memcpy(ipv4_raw, data, addr_bytes);
             read_size += addr_bytes;
             data += addr_bytes;

--- a/Server/src/bgp/linkstate/MPLinkStateAttr.cpp
+++ b/Server/src/bgp/linkstate/MPLinkStateAttr.cpp
@@ -352,9 +352,8 @@ namespace bgp_msg {
                         val_ss << ", " << value_16bit;
                 }
 
-                memcpy(parsed_data->ls_attrs[ATTR_NODE_MT_ID].data(), val_ss.str().data(), val_ss.str().length());
+                strncpy((char *)parsed_data->ls_attrs[ATTR_NODE_MT_ID].data(), val_ss.str().data(), val_ss.str().length()+1);
                 // LOG_INFO("%s: bgp-ls: parsed node MT_ID %s (len=%d)", peer_addr.c_str(), val_ss.str().c_str(), len);
-
                 break;
 
             case ATTR_NODE_NAME:

--- a/Server/src/bgp/parseBGP.cpp
+++ b/Server/src/bgp/parseBGP.cpp
@@ -617,8 +617,10 @@ void parseBGP::UpdateDbBgpLs(bool remove, bgp_msg::UpdateMsg::parsed_data_ls ls_
                 (*it).isIPv4 = false;
             }
 
-            if (ls_attrs.find(bgp_msg::MPLinkStateAttr::ATTR_NODE_MT_ID) != ls_attrs.end())
-                memcpy(&(*it).mt_id, ls_attrs[bgp_msg::MPLinkStateAttr::ATTR_NODE_MT_ID].data(), 4);
+            if (ls_attrs.find(bgp_msg::MPLinkStateAttr::ATTR_NODE_MT_ID) != ls_attrs.end()) {
+                strncpy((char *)&(*it).mt_id, (char *)ls_attrs[bgp_msg::MPLinkStateAttr::ATTR_NODE_MT_ID].data(),
+                       strlen((char *)ls_attrs[bgp_msg::MPLinkStateAttr::ATTR_NODE_MT_ID].data()) + 1);
+            }
 
             if (ls_attrs.find(bgp_msg::MPLinkStateAttr::ATTR_NODE_FLAG) != ls_attrs.end())
                 memcpy((*it).flags, ls_attrs[bgp_msg::MPLinkStateAttr::ATTR_NODE_FLAG].data(), sizeof((*it).flags));


### PR DESCRIPTION
This pull request has the following fixes -
1. Default route advertisements (v4 and v6), if the BGP update contains default route, BMP server should publish to kafka.
2. Linkstate Node MT_ID is an array and the entire array should be published in kafka.