### PR TITLE
Allow bind IPs to be specified

### DIFF
--- a/Server/src/Config.cpp
+++ b/Server/src/Config.cpp
@@ -38,6 +38,8 @@ Config::Config() {
     bmp_buffer_size     = 15 * 1024 * 1024; // 15MB
     svr_ipv6            = false;
     svr_ipv4            = true;
+    bind_ipv4           = "";
+    bind_ipv6           = "";
     heartbeat_interval  = 60 * 5;        // Default is 5 minutes
     kafka_brokers       = "localhost:9092";
     tx_max_bytes        = 1000000;
@@ -167,6 +169,19 @@ void Config::parseBase(const YAML::Node &node) {
         }
     }
 
+    if (node["listen_ipv4"]) {
+        bind_ipv4 = node["listen_ipv4"].as<std::string>();
+
+        if (debug_general)
+            std::cout << "   Config: listen_ipv4: " << bind_ipv4 << "\n";
+    }
+
+    if (node["listen_ipv6"]) {
+        bind_ipv6 = node["listen_ipv6"].as<std::string>();
+
+        if (debug_general)
+            std::cout << "   Config: listen_ipv6: " << bind_ipv6 << "\n";
+    }
 
     if (node["listen_mode"]) {
         try {

--- a/Server/src/Config.h
+++ b/Server/src/Config.h
@@ -33,6 +33,8 @@ public:
 
     std::string kafka_brokers;            ///< metadata.broker.list
     uint16_t    bmp_port;                 ///< BMP listening port
+    std::string bind_ipv4;                ///< IP to listen on for IPv4
+    std::string bind_ipv6;                ///< IP to listen on for IPv6
 
     int         bmp_buffer_size;          ///< BMP buffer size in bytes (min is 2M max is 128M)
     bool        svr_ipv4;                 ///< Indicates if server should listen for IPv4 connections

--- a/Server/src/bmp/BMPListener.cpp
+++ b/Server/src/bmp/BMPListener.cpp
@@ -51,9 +51,7 @@ BMPListener::BMPListener(Logger *logPtr, Config *config) {
     svr_addr.sin_port        = htons(cfg->bmp_port);
 
     if(cfg->bind_ipv4.length()) {
-        struct sockaddr_in sa;
-        inet_pton(AF_INET, cfg->bind_ipv4.c_str(), &(sa.sin_addr.s_addr));
-        svr_addr.sin_addr.s_addr = sa.sin_addr.s_addr;
+        inet_pton(AF_INET, cfg->bind_ipv4.c_str(), &(svr_addr.sin_addr.s_addr));
     } else {
         svr_addr.sin_addr.s_addr = INADDR_ANY;
     }
@@ -63,9 +61,7 @@ BMPListener::BMPListener(Logger *logPtr, Config *config) {
     svr_addrv6.sin6_scope_id = 0;
 
     if(cfg->bind_ipv6.length()) {
-        struct sockaddr_in6 sa;
-        inet_pton(AF_INET6, cfg->bind_ipv6.c_str(), &(sa.sin6_addr));
-        svr_addrv6.sin6_addr = sa.sin6_addr;
+        inet_pton(AF_INET6, cfg->bind_ipv6.c_str(), &(svr_addrv6.sin6_addr));
     } else {
         svr_addrv6.sin6_addr = in6addr_any;
     }


### PR DESCRIPTION
Currently the logic binds to all interfaces, there are occasions where this is not ideal, such as where there is a dedicated interface to an isolated network.

This adds 2 new base properties:

* listen_ipv4 - Takes an IPv4 address to bind to
* listen_ipv6 - Takes an IPv6 address to bind to

The default behaviour is still to bind to all interfaces, maintaining compatibility.

Invalid bind addresses result in a throw of either 'ERROR: Cannot bind to IPv4 address and port' or 'ERROR: Cannot bind to IPv6 address and port'.