### PR TITLE
Fix use of uninitialized variables pointed out by Clang

### DIFF
--- a/Server/src/bgp/ExtCommunity.cpp
+++ b/Server/src/bgp/ExtCommunity.cpp
@@ -397,7 +397,7 @@ namespace bgp_msg {
             }
 
             case EXT_OPAQUE_CP_ORF:
-                val_ss << "cp-orf=" << val_16b << ":" << val_32b;
+                val_ss << "cp-orf";
                 break;
 
             case EXT_OPAQUE_OSPF_ROUTE_TYPE: {

--- a/Server/src/bgp/linkstate/MPLinkStateAttr.cpp
+++ b/Server/src/bgp/linkstate/MPLinkStateAttr.cpp
@@ -471,11 +471,9 @@ namespace bgp_msg {
                     value_32bit = 0;
                     memcpy(&value_32bit, data, len);
                     bgp::SWAP_BYTES(&value_32bit, len);
+                    memcpy(parsed_data->ls_attrs[ATTR_LINK_IGP_METRIC].data(), &value_32bit, 4);
+                    SELF_DEBUG("%s: bgp-ls: parsed link IGP metric attribute: metric = %u", peer_addr.c_str(), value_32bit);
                 }
-
-                memcpy(parsed_data->ls_attrs[ATTR_LINK_IGP_METRIC].data(), &value_32bit, 4);
-
-                SELF_DEBUG("%s: bgp-ls: parsed link IGP metric attribute: metric = %u", peer_addr.c_str(), value_32bit);
                 break;
 
             case ATTR_LINK_IPV4_ROUTER_ID_REMOTE:


### PR DESCRIPTION
I'm not familiar with CP-ORF, but from what I could tell there is nothing in the "value" portion of the opaque community. Is that correct?