### PR TITLE
Fix several compiler warnings

### DIFF
--- a/Server/src/Config.cpp
+++ b/Server/src/Config.cpp
@@ -702,7 +702,7 @@ void Config::parseMapping(const YAML::Node &node) {
                             if (cur_node["asn"][i].Type() == YAML::NodeType::Scalar) {
                                 try {
                                     uint32_t asn = cur_node["asn"][i].as<std::uint32_t>();
-                                    match_peer_group_by_asn[name].push_back(cur_node["asn"][i].as<std::uint32_t>());
+                                    match_peer_group_by_asn[name].push_back(asn);
                                 } catch (YAML::TypedBadConversion<std::string> err) {
                                     printWarning(
                                             "mapping.groups.peer_group.asn int parse error. ASN must be uint32: ",

--- a/Server/src/bgp/ExtCommunity.cpp
+++ b/Server/src/bgp/ExtCommunity.cpp
@@ -361,7 +361,6 @@ namespace bgp_msg {
      */
     std::string ExtCommunity::decodeType_Opaque(const extcomm_hdr &ec_hdr) {
         std::stringstream   val_ss;
-        uint16_t            val_16b;
         uint32_t            val_32b;
 
         switch(ec_hdr.low_type) {

--- a/Server/src/bgp/MPReachAttr.cpp
+++ b/Server/src/bgp/MPReachAttr.cpp
@@ -28,7 +28,7 @@ namespace bgp_msg {
  * \param [in]     enable_debug             Debug true to enable, false to disable
  */
 MPReachAttr::MPReachAttr(Logger *logPtr, std::string peerAddr, BMPReader::peer_info *peer_info, bool enable_debug)
-    : logger{logPtr}, peer_info{peer_info}, debug{enable_debug} {
+    : debug{enable_debug}, logger{logPtr}, peer_info{peer_info} {
         this->peer_addr = peerAddr;
 }
 

--- a/Server/src/bgp/MPUnReachAttr.cpp
+++ b/Server/src/bgp/MPUnReachAttr.cpp
@@ -27,7 +27,7 @@ namespace bgp_msg {
  * \param [in]     enable_debug             Debug true to enable, false to disable
  */
 MPUnReachAttr::MPUnReachAttr(Logger *logPtr, std::string peerAddr, BMPReader::peer_info *peer_info, bool enable_debug)
-        : logger{logPtr}, debug{enable_debug}{
+        : debug{enable_debug}, logger{logPtr} {
     this->peer_addr = peerAddr;
     this->peer_info = peer_info;
 }

--- a/Server/src/bgp/UpdateMsg.cpp
+++ b/Server/src/bgp/UpdateMsg.cpp
@@ -34,8 +34,8 @@ namespace bgp_msg {
  */
 UpdateMsg::UpdateMsg(Logger *logPtr, std::string peerAddr, std::string routerAddr, BMPReader::peer_info *peer_info,
                      bool enable_debug)
-        : logger(logPtr),
-          debug(enable_debug),
+        : debug(enable_debug),
+          logger(logPtr),
           peer_info(peer_info) {
 
     this->peer_addr = peerAddr;

--- a/Server/src/bmp/BMPListener.cpp
+++ b/Server/src/bmp/BMPListener.cpp
@@ -232,8 +232,6 @@ void BMPListener::accept_connection(ClientInfo &c, bool isIPv4) {
     sockaddr_in *v4_addr = (sockaddr_in *) &c.c_addr;
     sockaddr_in6 *v6_addr = (sockaddr_in6 *) &c.c_addr;
 
-    uint8_t addr_fam = isIPv4 ? PF_INET : PF_INET6;
-
     bzero(c.c_ip, sizeof(c.s_ip));
     bzero(c.c_ip, sizeof(c.c_ip));
 

--- a/Server/src/bmp/BMPReader.cpp
+++ b/Server/src/bmp/BMPReader.cpp
@@ -409,9 +409,11 @@ void BMPReader::disconnect(BMPListener::ClientInfo *client, MsgBusInterface *mbu
 void BMPReader::hashRouter(BMPListener::ClientInfo *client,MsgBusInterface::obj_router &r_object ) {
     char *hash_val;
     if(r_object.hash_type==2)
-          hash_val=r_object.bgp_id;
+        hash_val=r_object.bgp_id;
     else if(r_object.hash_type==1)
-          hash_val=(char *)r_object.name;
+        hash_val=(char *)r_object.name;
+    else // assume type 0
+        hash_val=(char *)r_object.ip_addr;
 
     string c_hash_str;
     MsgBusInterface::hash_toStr(cfg->c_hash_id, c_hash_str);

--- a/Server/src/kafka/KafkaTopicSelector.cpp
+++ b/Server/src/kafka/KafkaTopicSelector.cpp
@@ -314,7 +314,6 @@ RdKafka::Topic * KafkaTopicSelector::initTopic(const std::string &topic_var,
                                                uint32_t peer_asn) {
     std::string errstr;
     char uint32_str[12];
-    topic_flags tflags;
 
     // Get the actual topic name based on var
     std::string topic_name = this->cfg->topic_names_map[topic_var];

--- a/Server/src/kafka/MsgBusImpl_kafka.cpp
+++ b/Server/src/kafka/MsgBusImpl_kafka.cpp
@@ -1165,9 +1165,9 @@ void msgBus_kafka::update_LsNode(obj_bgp_peer &peer, obj_path_attr &attr, std::l
 
             if ((uint32_t) *(node.igp_router_id+4) != 0) {
                 inet_ntop(PF_INET, node.igp_router_id+4, dr, sizeof(dr));
-                strncat(igp_router_id, "[", 1);
-                strncat(igp_router_id, dr, sizeof(dr));
-                strncat(igp_router_id, "]", 1);
+                strncat(igp_router_id, "[", sizeof(igp_router_id) - strlen(igp_router_id) - 1);
+                strncat(igp_router_id, dr, sizeof(igp_router_id) - strlen(igp_router_id) - 1);
+                strncat(igp_router_id, "]", sizeof(igp_router_id) - strlen(igp_router_id) - 1);
                 LOG_INFO("igp router id includes DR: %s %s", igp_router_id, dr);
             }
 
@@ -1301,9 +1301,9 @@ void msgBus_kafka::update_LsLink(obj_bgp_peer &peer, obj_path_attr &attr, std::l
 
             if ((uint32_t) *(link.igp_router_id+4) != 0) {
                 inet_ntop(PF_INET, link.igp_router_id+4, dr, sizeof(dr));
-                strncat(igp_router_id, "[", 1);
-                strncat(igp_router_id, dr, sizeof(dr));
-                strncat(igp_router_id, "]", 1);
+                strncat(igp_router_id, "[", sizeof(igp_router_id) - strlen(igp_router_id) - 1);
+                strncat(igp_router_id, dr, sizeof(igp_router_id) - strlen(igp_router_id) - 1);
+                strncat(igp_router_id, "]", sizeof(igp_router_id) - strlen(igp_router_id) - 1);
             }
 
             inet_ntop(PF_INET, link.remote_igp_router_id, remote_igp_router_id, sizeof(remote_igp_router_id));
@@ -1311,9 +1311,9 @@ void msgBus_kafka::update_LsLink(obj_bgp_peer &peer, obj_path_attr &attr, std::l
             if ((uint32_t) *(link.remote_igp_router_id+4) != 0) {
                 bzero(dr, sizeof(dr));
                 inet_ntop(PF_INET, link.remote_igp_router_id+4, dr, sizeof(dr));
-                strncat(remote_igp_router_id, "[", 1);
-                strncat(remote_igp_router_id, dr, sizeof(dr));
-                strncat(remote_igp_router_id, "]", 1);
+                strncat(remote_igp_router_id, "[", sizeof(remote_igp_router_id) - strlen(remote_igp_router_id) - 1);
+                strncat(remote_igp_router_id, dr, sizeof(remote_igp_router_id) - strlen(remote_igp_router_id) - 1);
+                strncat(remote_igp_router_id, "]", sizeof(remote_igp_router_id) - strlen(remote_igp_router_id) - 1);
             }
 
             inet_ntop(PF_INET, link.ospf_area_Id, ospf_area_id, sizeof(ospf_area_id));
@@ -1473,9 +1473,9 @@ void msgBus_kafka::update_LsPrefix(obj_bgp_peer &peer, obj_path_attr &attr, std:
 
             if ((uint32_t) *(prefix.igp_router_id+4) != 0) {
                 inet_ntop(PF_INET, prefix.igp_router_id+4, dr, sizeof(dr));
-                strncat(igp_router_id, "[", 1);
-                strncat(igp_router_id, dr, sizeof(dr));
-                strncat(igp_router_id, "]", 1);
+                strncat(igp_router_id, "[", sizeof(igp_router_id) - strlen(igp_router_id) - 1);
+                strncat(igp_router_id, dr, sizeof(igp_router_id) - strlen(igp_router_id) - 1);
+                strncat(igp_router_id, "]", sizeof(igp_router_id) - strlen(igp_router_id) - 1);
             }
 
 

--- a/Server/src/md5.cpp
+++ b/Server/src/md5.cpp
@@ -114,7 +114,7 @@ void MD5::update(FILE *file){
   unsigned char buffer[1024];
   int len;
 
-  while (len=fread(buffer, 1, 1024, file))
+  while ((len=fread(buffer, 1, 1024, file)))
     update(buffer, len);
 
   fclose (file);

--- a/Server/src/openbmp.cpp
+++ b/Server/src/openbmp.cpp
@@ -568,7 +568,7 @@ int main(int argc, char **argv) {
     // Make sure we have the required ARGS
     if (strlen(cfg.admin_id) <= 0) {
         cout << "ERROR: Missing required 'admin ID', use -c <config> or -a <string> to set the collector admin ID" << endl;
-        return true;
+        return 2;
     }
 
     try {

--- a/Server/src/openbmp.cpp
+++ b/Server/src/openbmp.cpp
@@ -418,7 +418,6 @@ void runServer(Config &cfg) {
         // allocate and start a new bmp server
         BMPListener *bmp_svr = new BMPListener(logger, &cfg);
 
-        BMPListener::ClientInfo client;
         collector_update_msg(kafka, cfg, MsgBusInterface::COLLECTOR_ACTION_STARTED);
         last_heartbeat_time = time(NULL);
 
@@ -524,7 +523,6 @@ void runServer(Config &cfg) {
 
                         // Send heartbeat if needed
                         if ( (time(NULL) - last_heartbeat_time) >= cfg.heartbeat_interval) {
-                            BMPListener::ClientInfo client;
                             collector_update_msg(kafka, cfg, MsgBusInterface::COLLECTOR_ACTION_HEARTBEAT);
                             last_heartbeat_time = time(NULL);
                         }


### PR DESCRIPTION
This fixes almost all compiler warnings generated by building the current master with clang (Apple LLVM version 9.0.0 (clang-900.0.37)).
(The only warning not fixed is that described in Issue #52.)

It would probably be best to review each commit separately as I have documented the changes and any concerns I have in the commit message.