### PR TITLE
Allow publication to kafka topics to be selectively disabled

### DIFF
--- a/Server/openbmpd.conf
+++ b/Server/openbmpd.conf
@@ -135,6 +135,8 @@ kafka:
   #
   #   Global/system variables will be replaced at runtime based on mappings and content.
   #
+  #   Topics names may be set to null (or the empty string) to disable production of associated messages.
+  #
   # NOTE: If you define a system variable (e.g. router_group, peer_group, ...) and there is no match,
   #        "default" will be used in its place.
   topics:

--- a/Server/src/Config.cpp
+++ b/Server/src/Config.cpp
@@ -592,9 +592,13 @@ void Config::parseTopics(const YAML::Node &node) {
         for (YAML::const_iterator it = node["names"].begin(); it != node["names"].end(); ++it) {
             try {
                 // Only add topic names that are initialized, otherwise ignore them
-                if (topic_names_map.find(it->first.as<std::string>()) != topic_names_map.end())
-                    topic_names_map[it->first.as<std::string>()] = it->second.as<std::string>();
-                else if (debug_general)
+                if (topic_names_map.find(it->first.as<std::string>()) != topic_names_map.end()) {
+                    if (it->second.Type() == YAML::NodeType::Null) {
+                        topic_names_map[it->first.as<std::string>()] = "";
+                    } else {
+                        topic_names_map[it->first.as<std::string>()] = it->second.as<std::string>();
+                    }
+                } else if (debug_general)
                     std::cout << "   Ignore: '" << it->first.as<std::string>()
                               << "' is not a valid topic name entry" << std::endl;
 

--- a/Server/src/kafka/KafkaTopicSelector.cpp
+++ b/Server/src/kafka/KafkaTopicSelector.cpp
@@ -85,6 +85,17 @@ RdKafka::Topic * KafkaTopicSelector::getTopic(const std::string &topic_var,
 }
 
 /*********************************************************************//**
+ * Check if a topic is enabled
+ *
+ * \param [in]  topic_var       MSGBUS_TOPIC_VAR_<name>
+ *
+ * \return bool true if the topic is enabled, false otherwise
+***********************************************************************/
+bool KafkaTopicSelector::topicEnabled(const std::string &topic_var) {
+    return this->cfg->topic_names_map[topic_var].length() > 0;
+}
+
+/*********************************************************************//**
  * Lookup peer group
  *
  * \param [in]  hostname        hostname/fqdn of the peer

--- a/Server/src/kafka/KafkaTopicSelector.h
+++ b/Server/src/kafka/KafkaTopicSelector.h
@@ -81,6 +81,15 @@ public:
                               uint32_t peer_asn);
 
     /*********************************************************************//**
+     * Check if a topic is enabled
+     *
+     * \param [in]  topic_var       MSGBUS_TOPIC_VAR_<name>
+     *
+     * \return bool true if the topic is enabled, false otherwise
+     ***********************************************************************/
+    bool topicEnabled(const std::string &topic_var);
+
+    /*********************************************************************//**
      * Lookup router group
      *
      * \param [in]  hostname          hostname/fqdn of the router

--- a/Server/src/kafka/MsgBusImpl_kafka.cpp
+++ b/Server/src/kafka/MsgBusImpl_kafka.cpp
@@ -373,6 +373,11 @@ void msgBus_kafka::produce(const char *topic_var, char *msg, size_t msg_size, in
         sleep(1);
     }
 
+    // if topic is disabled, don't bother producing the message
+    // TODO: it would be more efficient to move this check to the top of the various update_* methods, but I'm not sure which parts of these methods have side-effects that need to be preserved.
+    if (!topicSel->topicEnabled(topic_var))
+        return;
+
     char headers[256];
     len = snprintf(headers, sizeof(headers), "V: %s\nC_HASH_ID: %s\nT: %s\nL: %lu\nR: %d\n\n",
             MSGBUS_API_VERSION, collector_hash.c_str(), topic_var, msg_size, rows);
@@ -1544,6 +1549,10 @@ void msgBus_kafka::send_bmp_raw(u_char *r_hash, obj_bgp_peer &peer, u_char *data
 
         sleep(2);
     }
+
+    // if topic is disabled, don't bother producing the message
+    if (!topicSel->topicEnabled(MSGBUS_TOPIC_VAR_BMP_RAW))
+        return;
 
     char headers[256];
     size_t hdr_len = snprintf(headers, sizeof(headers), "V: %s\nC_HASH_ID: %s\nR_HASH: %s\nR_IP: %s\nL: %lu\n\n",


### PR DESCRIPTION
Any topic name configured to be `null` (or set to the empty string) will be disabled, and no messages will be published. Disabled topics will not be created in Kafka if they don't already exist. I have tested that disabling all topics does work, though I'm not sure what the point of this would be.

Someone more familiar with the code may/should be able to move the `topicEnabled` checks into the various `update_*` methods and save some needless message generation, but some of these methods appear to have side-effects, so I took the safe route and chose to simply not publish messages to disabled topics.