### PR TITLE
Write correct PID to PID file

### DIFF
--- a/Server/src/openbmp.cpp
+++ b/Server/src/openbmp.cpp
@@ -122,7 +122,7 @@ void daemonize() {
 
     // Write PID to PID file if requested
     if (pid_filename != NULL) {
-        //pid_t pid = getpid();
+        pid_t pid = getpid();
         ofstream pfile(pid_filename);
 
         if (pfile.is_open()) {


### PR DESCRIPTION
At this point of the program, we are in the child process and `pid`
variable is always 0. Therefore, the call to `getpid()` is needed to
get the actual value.