### PR TITLE
add lz4 to ld-config

### DIFF
--- a/Server/CMakeLists.txt
+++ b/Server/CMakeLists.txt
@@ -134,7 +134,7 @@ if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" OR CMAKE_COMPILER_IS_GNUCXX)
 endif()
 
 # Set the libs to link
-set (LIBS pthread ${LIBYAML_CPP_LIBRARY} ${LIBRDKAFKA_CPP_LIBRARY} ${LIBRDKAFKA_LIBRARY} z ${SSL_LIBS} dl)
+set (LIBS pthread ${LIBYAML_CPP_LIBRARY} ${LIBRDKAFKA_CPP_LIBRARY} ${LIBRDKAFKA_LIBRARY} z ${SSL_LIBS} dl lz4)
 
 # Set the binary
 add_executable (openbmpd ${SRC_FILES})


### PR DESCRIPTION
Allow to build properly. Without it:

```
[100%] Linking CXX executable openbmpd
/usr/bin/ld: /usr/lib/gcc/x86_64-linux-gnu/8/../../../x86_64-linux-gnu/librdkafka.a(rdkafka_lz4.o): in function `rd_kafka_lz4_decompress':
(.text+0x5a): undefined reference to `LZ4F_createDecompressionContext'
```